### PR TITLE
excess hovering through skills from navbar fixed

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -14,7 +14,7 @@ export const NavBar = () => {
 
   useEffect(() => {
     const onScroll = () => {
-      if (window.scrollY > 50) {
+      if (window.scrollY > 100) {
         setScrolled(true);
       } else {
         setScrolled(false);


### PR DESCRIPTION
I have changed window.scrollY to be > 100. This will not hover in excess when you do it from navbar. pls check and merge.