### PR TITLE
fixed animation speed and image size

### DIFF
--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -44,15 +44,15 @@ export const Contact = () => {
         width: `${mouseOver ? "100%" : "90%"}`,
         margin: "auto",
         borderRadius: `${mouseOver ? "0" : "50px"}`,
-        transition: "all 0.4s ",
+        transition: "all 1s ",
       }}
     >
       <Container>
         <Row className="align-items-center">
           <Col size={12} md={6}>
             <AnimationOnScroll animateIn="animate__animated animate__zoomIn">
-              <LazyLoad width={785} height={589} offsetVertical={300}>
-                <img src={contactImg} alt="Contact Us" style={{ width: "785px", height: "589px" }} />
+              <LazyLoad width={500} height={400} offsetVertical={300}>
+                <img src={contactImg} alt="Contact Us" style={{ width: "500px", height: "400px" }} />
               </LazyLoad>
             </AnimationOnScroll>
           </Col>


### PR DESCRIPTION
## Issue Addressed
Closes #29
(Animations are too fast)

## Proposed Changes and Benefits
I've made some improvements to the **Contact Us** part of the website. I've slowed down the animation speed, which enhances the user experience, especially when they reach the "Contact Us" section. Additionally, I've adjusted the size of the image so that it no longer obstructs the "Contact Us" form. This change ensures that users feel more at ease when filling out the form, making for a smoother interaction with the website.

## Screenshots
Before:
<img width="1258" alt="before" src="https://github.com/lazyjinchuriki/portfolio/assets/46776916/1ccca73a-b42b-400a-b04e-401fcac8e4b6">

After:
<img width="1131" alt="after" src="https://github.com/lazyjinchuriki/portfolio/assets/46776916/23e4f439-9d73-4541-989b-5a8132435420">




